### PR TITLE
Fix verifySmsTemplate bug.

### DIFF
--- a/src/Toplan/LaravelSms/SmsManager.php
+++ b/src/Toplan/LaravelSms/SmsManager.php
@@ -350,9 +350,7 @@ class SmsManager
         foreach ($enableAgents as $name => $opts) {
             if (isset($agentsConfig["$name"])) {
                 if (isset($agentsConfig["$name"]['verifySmsTemplateId'])) {
-                    array_push($templates, [
-                        $name => $agentsConfig["$name"]['verifySmsTemplateId']
-                    ]);
+                    $templates[$name] = $agentsConfig["$name"]['verifySmsTemplateId'];
                 }
             }
         }


### PR DESCRIPTION
这点排查了2天。 templates的数组形式应该为
```php
    [
        'Submail'=>'1q2w3e4r',
        'YunTongXun'=>'1q2w3e4r'
    ]
```
而不是

```php
    [
        ['Submail'=>'1q2w3e4r'],
        ['YunTongXun'=>'1q2w3e4r']
    ]
```