### PR TITLE
fixed bug of ErrorException: Constant CUSTOM_RULE already defined 

### DIFF
--- a/src/Toplan/LaravelSms/SmsManagerServiceProvider.php
+++ b/src/Toplan/LaravelSms/SmsManagerServiceProvider.php
@@ -58,7 +58,9 @@ class SmsManagerServiceProvider extends ServiceProvider
     protected function initPhpSms()
     {
         //export custom rule flag value
-        if (! defined('CUSTOM_RULE')) define('CUSTOM_RULE', SmsManager::CUSTOM_RULE_FLAG);
+        if (! defined('CUSTOM_RULE')) {
+            define('CUSTOM_RULE', SmsManager::CUSTOM_RULE_FLAG);
+        }
 
         // define how to use queue
         $queueJob = config('laravel-sms.queueJob', 'App\Jobs\SendReminderSms');

--- a/src/Toplan/LaravelSms/SmsManagerServiceProvider.php
+++ b/src/Toplan/LaravelSms/SmsManagerServiceProvider.php
@@ -58,7 +58,7 @@ class SmsManagerServiceProvider extends ServiceProvider
     protected function initPhpSms()
     {
         //export custom rule flag value
-        define('CUSTOM_RULE', SmsManager::CUSTOM_RULE_FLAG);
+        if (! defined('CUSTOM_RULE')) define('CUSTOM_RULE', SmsManager::CUSTOM_RULE_FLAG);
 
         // define how to use queue
         $queueJob = config('laravel-sms.queueJob', 'App\Jobs\SendReminderSms');

--- a/src/Toplan/LaravelSms/SmsManagerServiceProvider.php
+++ b/src/Toplan/LaravelSms/SmsManagerServiceProvider.php
@@ -58,7 +58,7 @@ class SmsManagerServiceProvider extends ServiceProvider
     protected function initPhpSms()
     {
         //export custom rule flag value
-        if (! defined('CUSTOM_RULE')) {
+        if (!defined('CUSTOM_RULE')) {
             define('CUSTOM_RULE', SmsManager::CUSTOM_RULE_FLAG);
         }
 


### PR DESCRIPTION
fixed bug of `ErrorException: Constant CUSTOM_RULE already defined ` when running phpunit

```
Time: 136 ms, Memory: 16.00Mb

There was 1 error:

1) ExampleTest::testBasicExample
ErrorException: Constant CUSTOM_RULE already defined

/home/iat/workspace/code/ucenter/vendor/toplan/laravel-sms/src/Toplan/LaravelSms/SmsManagerServiceProvider.php:61
/home/iat/workspace/code/ucenter/vendor/toplan/laravel-sms/src/Toplan/LaravelSms/SmsManagerServiceProvider.php:47
/home/iat/workspace/code/ucenter/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:531
/home/iat/workspace/code/ucenter/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php:74
/home/iat/workspace/code/ucenter/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:507
/home/iat/workspace/code/ucenter/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/RegisterProviders.php:17
/home/iat/workspace/code/ucenter/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:203
/home/iat/workspace/code/ucenter/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php:208
/home/iat/workspace/code/ucenter/tests/TestCase.php:14
/home/iat/workspace/code/ucenter/vendor/laravel/framework/src/Illuminate/Foundation/Testing/ApplicationTrait.php:34
/home/iat/workspace/code/ucenter/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestCase.php:36
```